### PR TITLE
🪄Feat: Add Leaderboard and MatchSchedule components for match display

### DIFF
--- a/src/app/match/football.tsx
+++ b/src/app/match/football.tsx
@@ -1,53 +1,110 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     Card,
     CardContent,
 } from "@/components/ui/card";
 import Podium from '@/components/Podium';
+import MatchSchedule from '@/components/MatchSchedule';
+import Leaderboard from '@/components/Leaderboard';
 
 export default function FootballContent() {
+    const [podiumData, setPodiumData] = useState<{ team: string; rank: number; title: string; score: number; color: string; }[]>([]);
     // Mock data
-    const podiumData = [
+    const mockMatches = [
         {
-            team: "สีเขียว นาคา",
-            rank: 1,
-            title: "ชนะเลิศอันดับที่ 1",
-            score: 150,
-            color: 'bg-green-300',
+            id: "1",
+            matchName: "นาคา กับ เอราวัณ",
+            location: "สนามเชาวน์มณีวงษ์",
+            date: "2025-02-01 14:00",
+            type: "free-for-all",
+            participants: [
+                { id: "1a", team: { id: "team1", name: "สีเขียว นาคา" }, rank: 1, score: 5, point: 3 },
+                { id: "1a", team: { id: "team1", name: "สีเขียว นาคา" }, rank: 1, score: 5, point: 3 },
+                { id: "1a", team: { id: "team1", name: "สีเขียว นาคา" }, rank: 1, score: 5, point: 3 },
+                { id: "1a", team: { id: "team1", name: "สีเขียว นาคา" }, rank: 1, score: 5, point: 3 },
+                { id: "1b", team: { id: "team2", name: "สีชมพู เอราวัณ1" }, score: 0, point: 0 },
+                { id: "1b", team: { id: "team2", name: "สีชมพู เอราวัณ2" }, rank: 4, score: 0, point: 0 },
+                { id: "1b", team: { id: "team2", name: "สีชมพู เอราวัณ3" }, rank: 2, score: 0, point: 0 },
+            ],
         },
         {
-            team: "สีแดง หงส์เพลิง",
-            rank: 2,
-            title: "รองชนะเลิศอันดับที่ 1",
-            score: 100,
-            color: 'bg-red-300',
+            id: "2",
+            matchName: "หงส์เพลิง กับ กิเลนทองคำ",
+            location: "สนามเชาวน์มณีวงษ์",
+            date: "2025-02-01 15:00",
+            type: "duel",
+            participants: [
+                { id: "2a", team: { id: "team3", name: "สีแดง หงส์เพลิง" } },
+                { id: "2b", team: { id: "team4", name: "สีเหลือง กิเลนทองคำ" } },
+            ],
         },
-        {
-            team: "สีเหลือง กิเลนทองคำ",
-            rank: 3,
-            title: "รองชนะเลิศอันดับที่ 2",
-            score: 80,
-            color: 'bg-yellow-300',
-        },
-        {
-            team: "สีน้ำเงิน สุบรรณนที",
-            rank: 4,
-            title: "รองชนะเลิศอันดับที่ 3",
-            score: 50,
-            color: 'bg-blue-300',
-        },
-        {
-            team: "สีชมพู เอราวัณ",
-            rank: 5,
-            title: "รองชนะเลิศอันดับที่ 4",
-            score: 30,
-            color: 'bg-pink-300',
-        }
     ];
 
-    const sortedTeams = [4, 2, 1, 3, 5].map((rank) =>
-        podiumData.find((team) => team.rank === rank)
-    );
+    useEffect(() => {
+        const teamPoints = mockMatches.reduce<Record<string, { name: string; points: number }>>(
+            (acc, match) => {
+                match.participants.forEach((participant) => {
+                    const teamId = participant.team.id;
+                    const teamName = participant.team.name;
+                    const points = participant.point ?? 0;
+    
+                    if (!acc[teamId]) {
+                        acc[teamId] = { name: teamName, points: 0 };
+                    }
+                    acc[teamId].points += points;
+                });
+                return acc;
+            },
+            {}
+        );
+    
+        const sortedTeams = Object.entries(teamPoints)
+            .map(([id, { name, points }]) => ({
+                id,
+                name,
+                points,
+            }))
+            .sort((a, b) => b.points - a.points)
+            .map((team, index) => {
+                // Generate color from team name (temporary)
+                const color = team.name.includes("เขียว")
+                    ? "bg-green-300"
+                    : team.name.includes("แดง")
+                    ? "bg-red-300"
+                    : team.name.includes("เหลือง")
+                    ? "bg-yellow-300"
+                    : team.name.includes("น้ำเงิน")
+                    ? "bg-blue-300"
+                    : team.name.includes("ชมพู")
+                    ? "bg-pink-300"
+                    : "bg-gray-300";
+    
+                // Generate title based on rank
+                const titles = [
+                    "ชนะเลิศอันดับที่ 1",
+                    "รองชนะเลิศอันดับที่ 1",
+                    "รองชนะเลิศอันดับที่ 2",
+                    "รองชนะเลิศอันดับที่ 3",
+                    "รองชนะเลิศอันดับที่ 4",
+                ];
+                const title = `${titles[index] || `อันดับที่ ${index + 1}`}`;
+    
+                return {
+                    team: team.name,
+                    rank: index + 1,
+                    title,
+                    score: team.points,
+                    color,
+                };
+            });
+    
+        setPodiumData(sortedTeams);
+    }, []);
+    
+
+    const sortedTeams = [4, 2, 1, 3, 5]
+    .map((rank) => podiumData.find((team) => team.rank === rank))
+    .filter((team) => team !== undefined);
 
     return (
         <div>
@@ -57,8 +114,8 @@ export default function FootballContent() {
             <Card className="mt-4">
                 <CardContent>
                     <Section title="ผลการแข่งขัน">
-                        {/* <Podium teams={sortedTeams} /> */}
-                        Coming Soon...
+                        <Podium teams={sortedTeams} />
+                        <Leaderboard matches={mockMatches} />
                     </Section>
                 </CardContent>
             </Card>
@@ -66,7 +123,7 @@ export default function FootballContent() {
             <Card className="mt-4">
                 <CardContent>
                     <Section title="ตารางการแข่งขัน">
-                        Coming Soon...
+                        <MatchSchedule matches={mockMatches} />
                     </Section>
                 </CardContent>
             </Card>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+
+interface Team {
+    id: string;
+    name: string;
+}
+
+interface Participant {
+    id: string;
+    team: Team;
+    score?: number;
+    point?: number;
+}
+
+interface Match {
+    id: string;
+    participants: Participant[];
+}
+
+interface LeaderboardProps {
+    matches: Match[];
+}
+
+const Leaderboard: React.FC<LeaderboardProps> = ({ matches }) => {
+    // Aggregate scores for each team
+    const teamPoints = matches.reduce<Record<string, { name: string; totalPoints: number }>>(
+        (acc, match) => {
+            match.participants.forEach((participant) => {
+                const teamId = participant.team.id;
+                const teamName = participant.team.name;
+                const point = participant.point ?? 0;
+
+                if (!acc[teamId]) {
+                    acc[teamId] = { name: teamName, totalPoints: 0 };
+                }
+                acc[teamId].totalPoints += point;
+            });
+
+            return acc;
+        },
+        {}
+    );
+
+    // Sort teams by total points in descending order
+    const sortedTeams = Object.entries(teamPoints)
+        .map(([id, { name, totalPoints }]) => ({ id, name, totalPoints }))
+        .sort((a, b) => b.totalPoints - a.totalPoints);
+
+    // Determine row colors for the top 3
+    const getRowColor = (index: number) => {
+        switch (index) {
+            case 0:
+                return "bg-yellow-200"; // Gold
+            case 1:
+                return "bg-gray-200"; // Silver
+            case 2:
+                return "bg-orange-200"; // Bronze
+            default:
+                return "bg-gray-100"; // Default background
+        }
+    };
+
+    return (
+        <div>
+            {sortedTeams.length === 0 ? (
+                <p className="text-gray-500">No data available.</p>
+            ) : (
+                <div className="flex flex-col gap-4">
+                    {sortedTeams.map((team, index) => (
+                        <div
+                            key={team.id}
+                            className={`flex items-center justify-between px-4 py-2 rounded-lg ${getRowColor(
+                                index
+                            )}`}
+                        >
+                            {/* Rank */}
+                            <div className="flex items-center gap-4">
+                                <span className="text-lg font-bold text-gray-700">{index + 1}.</span>
+                                <span className="text-sm font-medium text-gray-800">{team.name}</span>
+                            </div>
+                            {/* Total Points */}
+                            <span className="text-sm font-bold text-gray-700">{team.totalPoints} pts</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default Leaderboard;

--- a/src/components/MatchSchedule.tsx
+++ b/src/components/MatchSchedule.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+
+interface Team {
+    id: string;
+    name: string;
+}
+
+interface Participant {
+    id: string;
+    team: Team;
+    rank?: number;
+    score?: number;
+    point?: number;
+}
+
+interface Match {
+    id: string;
+    matchName: string;
+    location: string | null;
+    date: string;
+    participants: Participant[];
+    type: string | null;
+}
+
+interface MatchScheduleProps {
+    matches: Match[];
+}
+
+const MatchSchedule: React.FC<MatchScheduleProps> = ({ matches }) => {
+    const getBadgeText = (rank: number | undefined) => {
+        if (!rank) return null;
+        switch (rank) {
+            case 1:
+                return "1st Place 🥇";
+            case 2:
+                return "2nd Place 🥈";
+            case 3:
+                return "3rd Place 🥉";
+            default:
+                return `${rank}th Place`;
+        }
+    };
+
+    return (
+        <div>
+            {matches.length === 0 ? (
+                <p className="text-gray-500">No matches scheduled.</p>
+            ) : (
+                matches.map((match, index) => (
+                    <div
+                        key={match.id}
+                        className="mt-4 flex flex-col gap-4 border-b border-gray-200 pb-4 mb-4 last:border-none last:pb-0 last:mb-0"
+                    >
+                        {/* Match Info */}
+                        <div>
+                            <p className="text-sm text-gray-500">{match.date}</p>
+                            <h3 className="text-lg font-medium">
+                                แมชท์ที่ {index + 1} | {match.matchName}
+                            </h3>
+                            <p className="text-sm text-gray-600">
+                                📍{match.location ?? "Location not specified"}
+                            </p>
+                        </div>
+
+                        {/* Participating Teams and Scores */}
+                        <div className="flex flex-col gap-4">
+                            {(
+                                match.type === "free-for-all"
+                                    ? match.participants
+                                        .slice()
+                                        .sort((a, b) => {
+                                            if (a.rank == null && b.rank == null) return 0;
+                                            if (a.rank == null) return 1;
+                                            if (b.rank == null) return -1; 
+                                            return a.rank - b.rank;
+                                        })
+                                    : match.participants
+                            ).map((participant) => (
+                                <div
+                                    key={participant.id}
+                                    className="flex items-center justify-between bg-gray-100 px-4 py-2 rounded-lg"
+                                >
+                                    <div className="flex items-center gap-2">
+                                        {/* Team Name */}
+                                        <span className="text-sm font-medium text-gray-800">
+                                            {participant.team.name}
+                                        </span>
+                                        {/* Badge for Rank */}
+                                        {match.type === "free-for-all" && participant.rank && (
+                                            <span className="bg-blue-100 text-blue-800 px-2 py-1 text-xs rounded font-semibold">
+                                                {getBadgeText(participant.rank)}
+                                            </span>
+                                        )}
+                                    </div>
+                                    {/* Score */}
+                                    <span className="text-sm font-bold text-gray-700">
+                                        {participant.score ?? "0"}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))
+            )}
+        </div>
+    );
+};
+
+export default MatchSchedule;


### PR DESCRIPTION
This pull request includes several changes to the `FootballContent` component to enhance the display of match schedules and leaderboards. The most important changes include adding new components, updating the state management, and modifying the rendering logic.

Enhancements to `FootballContent`:

* [`src/app/match/football.tsx`](diffhunk://#diff-fb1249037d83afa02b61104f52a99d3a36040ef064fe1006085d1b3953ca5204L1-R108): Added `useEffect` and `useState` to manage the state of podium data dynamically. Introduced mock match data and updated the rendering logic to display sorted teams and match schedules.

New components:

* [`src/components/Leaderboard.tsx`](diffhunk://#diff-7d53feaf9f5508a830181e76d932d9b14b3d66d656fdb2764cc6c0ab5ff39352R1-R91): Created a new `Leaderboard` component to aggregate and display team points from matches.
* [`src/components/MatchSchedule.tsx`](diffhunk://#diff-5e2becdc4e3a9115327ca58ef5db2342bc9a355dfeecf183afa8694b2d424bcdR1-R109): Created a new `MatchSchedule` component to display the schedule and details of matches, including participating teams and their scores.

Rendering updates:

* [`src/app/match/football.tsx`](diffhunk://#diff-fb1249037d83afa02b61104f52a99d3a36040ef064fe1006085d1b3953ca5204L60-R126): Updated the `FootballContent` component to render the `Podium`, `Leaderboard`, and `MatchSchedule` components within the appropriate sections.